### PR TITLE
Remove 'a7vicky' from OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,7 +7,6 @@ reviewers:
   - diakovnec
   - xiaoyu74
   - smarthall
-  - a7vicky
   - samanthajayasinghe
   - joshbranham
 
@@ -20,7 +19,6 @@ approvers:
   - diakovnec
   - xiaoyu74
   - smarthall
-  - a7vicky
   - MitaliBhalla
   - samanthajayasinghe
   - joshbranham


### PR DESCRIPTION
Removed 'a7vicky' from the list of owners as reviewers and approvers.
